### PR TITLE
generalize some instances, derive some others

### DIFF
--- a/src/Ditto/Core.hs
+++ b/src/Ditto/Core.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE LambdaCase #-}
@@ -29,10 +30,7 @@ data Proved a
       { pos :: FormRange
       , unProved :: a
       }
-  deriving Show
-
-instance Functor Proved where
-  fmap f (Proved posi a) = Proved posi (f a)
+  deriving (Show, Functor)
 
 -- | Utility Function: trivially prove nothing about ()
 unitProved :: FormId -> Proved ()
@@ -141,10 +139,7 @@ newtype View error v
   = View
       { unView :: [(FormRange, error)] -> v
       }
-  deriving (SG.Semigroup, Monoid)
-
-instance Functor (View e) where
-  fmap f (View g) = View $ f . g
+  deriving (SG.Semigroup, Monoid, Functor)
 
 ------------------------------------------------------------------------------
 -- * Form
@@ -176,6 +171,7 @@ instance Functor (View e) where
 -- applicative functor and can be used almost exactly like
 -- @digestive-functors <= 0.2@.
 newtype Form m input error view a = Form {unForm :: FormState m input (View error view, m (Result error (Proved a)))}
+  deriving Functor
 
 -- instance (Monad m) => Functor (Form m input view error) where
 --   fmap f (Form frm) =
@@ -222,11 +218,7 @@ bracketState k = do
   put $ FormRange startF1 endF2
   pure res
 
-instance (Functor m) => Functor (Form m input error view) where
-  fmap f form =
-    Form $ fmap (second (fmap (fmap (fmap f)))) (unForm form)
-
-instance (Functor m, Monoid view, Monad m, x ~ ()) => Applicative (Form m input error view) where
+instance (Functor m, Monoid view, Monad m) => Applicative (Form m input error view) where
   pure a =
     Form $ do
       i <- getFormId
@@ -263,7 +255,7 @@ instance (Functor m, Monoid view, Monad m, x ~ ()) => Applicative (Form m input 
             )
 
 -- ???
-instance (Functor m, Monoid view, Monad m, x ~ ()) => Monad (Form m input error view) where
+instance (Functor m, Monoid view, Monad m) => Monad (Form m input error view) where
   formA >>= formFunction = do
     Form $ do
       (view0, mfok) <- unForm formA

--- a/src/Ditto/Result.hs
+++ b/src/Ditto/Result.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveFunctor #-}
+
 -- | Module for the core result type, and related functions
 --
 module Ditto.Result
@@ -26,11 +28,7 @@ import qualified Data.List.NonEmpty as NE
 data Result e ok
   = Error [(FormRange, e)]
   | Ok ok
-  deriving (Show, Eq)
-
-instance Functor (Result e) where
-  fmap _ (Error x) = Error x
-  fmap f (Ok x) = Ok (f x)
+  deriving (Show, Eq, Functor)
 
 instance Monad (Result e) where
   return = Ok


### PR DESCRIPTION
some instances required the parameterised variable to unify with `()`, but this was unnecessary.
this PR also changes some functor instances to be derived